### PR TITLE
ADD: type export

### DIFF
--- a/packages/vv-schedule-parser/src/date/dateParser.ts
+++ b/packages/vv-schedule-parser/src/date/dateParser.ts
@@ -1,6 +1,7 @@
 import * as utils from '../common/utils'
 import { DateRangeNode } from '../common/dateRangeNode'
 import { DateRangeApplier} from '../common/dateRangeApplier'
+import type {DatesYAML, DateYAML} from '../type'
 
 const DefaultDateRange = { from: new Date(2000, 0, 1, 0, 0), to: new Date(3000, 11, 31, 24, 0)} // 2000-01-01 ~ 3000-12-31
 

--- a/packages/vv-schedule-parser/src/index.ts
+++ b/packages/vv-schedule-parser/src/index.ts
@@ -1,3 +1,4 @@
 export {TimeParser} from './time/timeParser'
 export {DateParser} from './date/dateParser'
 export {ScheduleParser} from './scheduleParser'
+export * from './type'

--- a/packages/vv-schedule-parser/src/scheduleParser.ts
+++ b/packages/vv-schedule-parser/src/scheduleParser.ts
@@ -1,5 +1,6 @@
 import { TimeParser } from './time/timeParser'
 import { DateParser } from './date/dateParser'
+import type {DatesYAML, WeekdayAndTimesYAML} from './type'
 
 export class ScheduleParser {
 

--- a/packages/vv-schedule-parser/src/time/timeParser.ts
+++ b/packages/vv-schedule-parser/src/time/timeParser.ts
@@ -2,6 +2,7 @@ import {Schedule} from './schedule'
 import * as utils from '../common/utils'
 import {DateRangeNode} from '../common/dateRangeNode'
 import {DateRangeApplier} from '../common/dateRangeApplier'
+import type {WeekdayAndTimesYAML} from '../type'
 
 
 export class TimeParser {

--- a/packages/vv-schedule-parser/src/type.ts
+++ b/packages/vv-schedule-parser/src/type.ts
@@ -1,13 +1,13 @@
-type DateYAML = {
+export type DateYAML = {
     "start"?: string,
     "end"?: string,
     "date"?: string
 }
-type DatesYAML = Array<DateYAML>
+export type DatesYAML = Array<DateYAML>
 
-type WeekdayAndTimeYAML = {
+export type WeekdayAndTimeYAML = {
     "start-time"?: string,
     "end-time"?: string,
     "weekdays"?: [string]
 }
-type WeekdayAndTimesYAML = Array<WeekdayAndTimeYAML>
+export type WeekdayAndTimesYAML = Array<WeekdayAndTimeYAML>


### PR DESCRIPTION
- 다른 저장소에서 scheduleParser 의 내부 데이터 구조를 input 타입으로 정의해야 하는 상황이 있어 type export를 모듈 진입점인 index.ts 파일에 추가
- 덤으로 패키지 안에서도 type import를 명시적으로 해서 IDE에서 타입 구조 자동 조회 기능을 사용할 수 있도록 한다.